### PR TITLE
Use proxy volumes for run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM alpine
 RUN apk add --no-cache socat
+VOLUME ["/local", "/tmp/out"]
+COPY helpers /local/helpers
 ENTRYPOINT ["socat"]

--- a/helpers/run.sh
+++ b/helpers/run.sh
@@ -12,7 +12,7 @@ if [ ! -f "/local/$dest" ]; then
     sed -i 's|^push|#push|' /etc/openvpn/openvpn.conf
     echo localhost | ovpn_initpki nopass
     easyrsa build-client-full host nopass
-    ovpn_getclient host | sed "s|localhost 1194|localhost 13194|;s|redirect-gateway.*|route ${network} ${netmask}|;" > "/local/$dest"
+    ovpn_getclient host | sed "s|localhost 1194|localhost 13194|;s|redirect-gateway.*|route ${network} ${netmask}|;" > "/tmp/out/$dest"
 fi
 
 exec ovpn_run

--- a/helpers/run.sh
+++ b/helpers/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 dest=${dest:-docker.ovpn}
+network=${DOCKER_NETWORK:-172.16.0.0}
+netmask=${DOCKER_NETMASK:-255.240.0.0}
 
 if [ ! -f "/local/$dest" ]; then
     echo "*** REGENERATING ALL CONFIGS ***"
@@ -10,10 +12,7 @@ if [ ! -f "/local/$dest" ]; then
     sed -i 's|^push|#push|' /etc/openvpn/openvpn.conf
     echo localhost | ovpn_initpki nopass
     easyrsa build-client-full host nopass
-    ovpn_getclient host | sed '
-    	s|localhost 1194|localhost 13194|;
-	s|redirect-gateway.*|route 172.16.0.0 255.240.0.0|;
-    ' > "/local/$dest"
+    ovpn_getclient host | sed "s|localhost 1194|localhost 13194|;s|redirect-gateway.*|route ${network} ${netmask}|;" > "/local/$dest"
 fi
 
 exec ovpn_run


### PR DESCRIPTION
This enables a one "image provides all" solution by creating different volumes:
* `/local`: used to provide the `run.sh` script file which is reusable in a `volumes_from`directive in docker-compose.yaml
* `/tmp/out`: as output volume where the `*.ovpn` config file is located after creation

`docker-compose.yaml`example:
```yaml
version: '2'
services:
  proxy:
    image: tkaefer/docker-mac-network
    ports:
      - "127.0.0.1:13194:13194"
    volumes:
      - ./out:/tmp/out
    command: TCP-LISTEN:13194,fork TCP:100.64.1.20:1194
  openvpn:
    image: kylemanna/openvpn
    volumes:
      - ./config:/etc/openvpn
    volumes_from:
      - proxy
    cap_add:
      - NET_ADMIN
    environment:
      dest: akka-mac-docker.ovpn
      DEBUG: '1'
    command: /local/helpers/run.sh
```

So no need to have `run.sh`locally available.